### PR TITLE
Fieldset fix

### DIFF
--- a/scarlet/cms/helpers.py
+++ b/scarlet/cms/helpers.py
@@ -227,7 +227,10 @@ class Fieldset(object):
     def __init__(self, form, name=None, fields=(),
                  classes=(), description=None):
         self.form = form
-        self.name, self.fields = name, fields
+        self.name= name
+        # Prevents to add form fields which have been deleted using pop() but
+        # exits on `fields` list of `Meta` on ModelForm class
+        self.fields = [field for field in fields if field in form.fields.keys()]
         self.classes = u' '.join(classes)
         self.description = description
 


### PR DESCRIPTION
Prevents to add form fields which have been removed using pop().

Example:

```
class ModuleEditForm(forms.ModelForm):
    def __init__(self, *args, **kwargs):
        super(ModuleEditForm, self).__init__(*args, **kwargs)
        self.fields.pop('description')

    class Meta:
        model = modules_models.Module
        fields = '__all__'
```

**description** field has been removed using **pop()**, however that field is on **fields** list. We don't want to display **description** field in form template.